### PR TITLE
Update dependency example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The package can be installed by adding `srp` to your list of dependencies in `mi
 ```elixir
 def deps do
   [
-    {:srp, "~> 0.1.0"}
+    {:srp, "~> 0.2.0"}
   ]
 end
 ```


### PR DESCRIPTION
The existing example does not pull the current version—it'll pull `0.1.1`. I was digging into the code to see why the generated salt was not respecting the `:random_bytes` option only to realize I wasn't using the current version. Hopefully this helps avoid confusion for others.